### PR TITLE
Fix validation issue

### DIFF
--- a/PoshToDon.psm1
+++ b/PoshToDon.psm1
@@ -105,7 +105,7 @@ function Set-MastodonAppRegistration {
         $RedirectUri = "urn:ietf:wg:oauth:2.0:oob",
         $Name = "PoshToDon",
         $VapidKey,
-        [ValidateSet({ $script:validScopes })]
+        [ValidateScript({ $_ -in $script:validScopes })]
         [string[]] $Scope = "read"
     )
 
@@ -185,7 +185,7 @@ function New-MastodonApplication {
     param(
         [string]$Name = "PoshToDon",
 
-        [ValidateSet({ $script:validScopes })]
+        [ValidateScript({ $_ -in $script:validScopes })]
         [string[]] $Scope = "read",
         
         [string] $Instance = $null


### PR DESCRIPTION
ValidateScript not being applied consistently. Receiving errors like this:

```
 454 |  … Application -Instance 'fosstodon.org' -Scope 'read', 'write:statuses'
     |                                                 ~~~~~~~~~~~~~~~~~~~~~~~~
     | Cannot validate argument on parameter 'Scope'. The argument "read" does not belong to the set
     | " $script:validScopes " specified by the ValidateSet attribute. Supply an argument that is in
     | the set and then try the command again.
```